### PR TITLE
Added client-side library version

### DIFF
--- a/browser/build.js
+++ b/browser/build.js
@@ -1,0 +1,14 @@
+var fs = require('fs');
+var path = require('path')
+
+var files = [
+  path.join('browser','intro.js'), 
+  'main.js', 
+  path.join('browser', 'outro.js')
+];
+
+var data = files.map(function(file) {
+  return fs.readFileSync(file);
+});
+
+fs.writeFileSync('browser/geohash.js', data.join('\n'));

--- a/browser/build.sh
+++ b/browser/build.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# build a client-side version
-cat browser/intro.js ./main.js browser/outro.js >browser/geohash.js

--- a/browser/intro.js
+++ b/browser/intro.js
@@ -1,3 +1,2 @@
 // intro.js
 (function(module) {
-

--- a/browser/outro.js
+++ b/browser/outro.js
@@ -1,3 +1,2 @@
-
 // outro.js
 })(window);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "scripts": {
         "test": "nodeunit tests/test.js",
-        "install": "browser/build.sh"
+        "install": "node browser/build.js"
     },
     "main": "./main",
     "license": "MIT",


### PR DESCRIPTION
I added a single line to package.json and several simple files in browser folder. As a result, npm install builds browser/geohash.js that can be loaded into browser without polluting browser's global namespace.

Exellent lib, should be on client too.
