### PR TITLE
Throwing error when using bboxes with numberOfChars === 0

### DIFF
--- a/main.js
+++ b/main.js
@@ -434,7 +434,7 @@ var neighbors_int = function(hash_int, bitDepth){
  * @returns {bboxes.hashList|Array}
  */
 var bboxes = function (minLat, minLon, maxLat, maxLon, numberOfChars) {
-  if (numberOfChars === 0) {
+  if (numberOfChars <= 0) {
     throw new Error("numberOfChars must be strictly positive");
   }
   numberOfChars = numberOfChars || 9;

--- a/main.js
+++ b/main.js
@@ -434,6 +434,9 @@ var neighbors_int = function(hash_int, bitDepth){
  * @returns {bboxes.hashList|Array}
  */
 var bboxes = function (minLat, minLon, maxLat, maxLon, numberOfChars) {
+  if (numberOfChars === 0) {
+    throw new Error("numberOfChars must be strictly positive");
+  }
   numberOfChars = numberOfChars || 9;
 
   var hashSouthWest = encode(minLat, minLon, numberOfChars);


### PR DESCRIPTION
Instead of returning geohashes with numberOfChars == 9, and potentially make an app crash with too many geohashes